### PR TITLE
Single run

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "ionic-app-scripts build",
     "ionic:build": "ionic-app-scripts build",
     "ionic:serve": "ionic-app-scripts serve",
-    "test": "karma start ./test-config/karma.conf.js"
+    "test": "karma start ./test-config/karma.conf.js",
+    "test-ci": "karma start ./test-config/karma.conf.js --single-run"
   },
   "dependencies": {
     "@angular/common": "2.4.8",


### PR DESCRIPTION
Add a single run `npm run test-ci` for use in continuous integration builds.

Granted this can be achieved by invoking karma directly in CI `karma start .. --single-run`, but this requires installing karma globally meaning we have to track a separate dependency / version in CI config.