### PR TITLE
Update the webpack config to fully ignore images

### DIFF
--- a/test-config/webpack.test.js
+++ b/test-config/webpack.test.js
@@ -20,7 +20,7 @@ module.exports = {
       },
       {
         test: /\.html$/,
-        loader: 'html-loader'
+        loader: 'html-loader?attrs=false'
       },
       {
         test: /\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico)$/,


### PR DESCRIPTION
Fixes #9 

Previously, while images would be loaded via the null-loader, if Webpack couldn't find the images it would still crash. This meant you had to use the real path to the images from your html file, like: `<img src="../../assets/img/test.png>`, which is not really going to work once deployed.

Instead I've updated the html-loader to not even try to load images. By default it tries to require any images it comes across, but by setting `attrs=false` it will no longer do that.