### PR TITLE
Change to allow ionic cli generate command to work with this project

### DIFF
--- a/ionic.config.json
+++ b/ionic.config.json
@@ -1,5 +1,7 @@
 {
-  "name": "test-test",
+  "name": "ionic-unit-testing-example",
   "app_id": "",
-  "projectTypeId": "ionic-angular"
+  "projectTypeId": "ionic-angular",
+  "v2": true,
+  "typescript": true
 }


### PR DESCRIPTION
Without this change to the `ionic.config.json` an error will occur when you attempt to use the Ionic CLI generate command. For instance:

```
leifwells$ ionic g page page3

**Generators are only available for Ionic 2 projects (CLI v2.2.2)**

Your system information:

Cordova CLI: 6.4.0 
Ionic Framework Version: 2.2.0
Ionic CLI Version: 2.2.2
Ionic App Lib Version: 2.2.1
Ionic App Scripts Version: 1.1.4
ios-deploy version: 1.9.0 
ios-sim version: 5.0.13 
OS: OS X El Capitan
Node Version: v6.9.1
Xcode version: Xcode 7.3.1 Build version 7D1014
```

The "v2" and "typescript" nodes in the `ionic.config.json` file are critical to CLI features.

ALSO: Changed the name node to `"name": "ionic-unit-testing-example",`