### PR TITLE
Update regex for Webpack ContextReplacementPlugin to work w/latest Ionic / Angular

### DIFF
--- a/test-config/webpack.test.js
+++ b/test-config/webpack.test.js
@@ -32,7 +32,7 @@ module.exports = {
   plugins: [
     new webpack.ContextReplacementPlugin(
       // The (\\|\/) piece accounts for path separators in *nix and Windows
-      /angular(\\|\/)core(\\|\/)(esm(\\|\/)src|src)(\\|\/)linker/,
+      /(ionic-angular)|(angular(\\|\/)core(\\|\/)@angular)/,
       root('./src'), // location of your src
       {} // a map of your routes
     )


### PR DESCRIPTION
Using the latest version of Ionic, I was seeing:

```
WARNING in ./~/@angular/core/@angular/core.es5.js
5870:15-36 Critical dependency: the request of a dependency is an expression

WARNING in ./~/@angular/core/@angular/core.es5.js
5886:15-102 Critical dependency: the request of a dependency is an expression

WARNING in ./~/ionic-angular/util/ng-module-loader.js
54:11-36 Critical dependency: the request of a dependency is an expression

WARNING in ./~/ionic-angular/util/ng-module-loader.js
69:11-36 Critical dependency: the request of a dependency is an expression
```

The updated regular expression should resolve both of these issues. See similar issue here: https://github.com/driftyco/ionic/issues/11072