### PR TITLE
Fix Test Warnings for Splash Screen & Status Bar

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -22,8 +22,8 @@ describe('MyApp Component', () => {
         IonicModule.forRoot(MyApp)
       ],
       providers: [
-        { provide: StatusBar, useClass: StatusBarMock},
-        { provide: SplashScreen, useClass: SplashScreenMock},
+        { provide: StatusBar, useClass: StatusBarMock },
+        { provide: SplashScreen, useClass: SplashScreenMock },
         { provide: Platform, useClass: PlatformMock }
       ]
     })

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -5,7 +5,11 @@ import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
 
 import { MyApp } from './app.component';
-import { PlatformMock } from '../../test-config/mocks-ionic';
+import {
+  PlatformMock,
+  StatusBarMock,
+  SplashScreenMock
+} from '../../test-config/mocks-ionic';
 
 describe('MyApp Component', () => {
   let fixture;
@@ -18,8 +22,8 @@ describe('MyApp Component', () => {
         IonicModule.forRoot(MyApp)
       ],
       providers: [
-        StatusBar,
-        SplashScreen,
+        { provide: StatusBar, useClass: StatusBarMock},
+        { provide: SplashScreen, useClass: SplashScreenMock},
         { provide: Platform, useClass: PlatformMock }
       ]
     })

--- a/test-config/mocks-ionic.ts
+++ b/test-config/mocks-ionic.ts
@@ -1,3 +1,6 @@
+import { StatusBar } from '@ionic-native/status-bar';
+import { SplashScreen } from '@ionic-native/splash-screen';
+
 export class PlatformMock {
   public ready(): Promise<{String}> {
     return new Promise((resolve) => {
@@ -60,5 +63,17 @@ export class PlatformMock {
 
   public getActiveElement(): any {
     return document['activeElement'];
+  }
+}
+
+export class StatusBarMock extends StatusBar {
+  styleDefault() {
+    return;
+  }
+}
+
+export class SplashScreenMock extends SplashScreen {
+  hide() {
+    return;
   }
 }


### PR DESCRIPTION
```
WARN: 'Native: tried calling StatusBar.styleDefault, but Cordova is not available. Make sure to include cordova.js or run in a device/simulator'
WARN: 'Native: tried calling StatusBar.styleDefault, but Cordova is not available. Make sure to include cordova.js or run in a device/simulator'
WARN: 'Native: tried calling SplashScreen.hide, but Cordova is not available. Make sure to include cordova.js or run in a device/simulator'
WARN: 'Native: tried calling SplashScreen.hide, but Cordova is not available. Make sure to include cordova.js or run in a device/simulator'
```

Mocking these two functions for testing solves the issue.